### PR TITLE
Reset the input value so that the user can re-upload the same file an…

### DIFF
--- a/d2l-file-uploader.js
+++ b/d2l-file-uploader.js
@@ -270,6 +270,7 @@ Polymer({
 			files[i] = event.target.files[i];
 		}
 		this._files = files;
+		event.target.value = '';
 	},
 
 	__onDragOver: function(event) {


### PR DESCRIPTION
…d the event will fire

The browse for file logic is inconsistent with the drag and drop logic, as well as the logic on the MVC version of this. The inconsistency is that we do not fire the d2l-file-uploader-files-added event if the user attempts to upload the same file twice in a row. 

This change resets the value of the input after we handle its on change event. This allows us to receive events if the user repeatedly uploads the same file.