### PR TITLE
fix: backporting Hindi translations to 2.x

### DIFF
--- a/localize-behavior.js
+++ b/localize-behavior.js
@@ -51,6 +51,12 @@ D2L.PolymerBehaviors.FileUploader.LocalizeBehaviorImpl = {
 						'browse_files': 'Parcourir les fichiers',
 						'choose_one_file_to_upload': 'Choisir un fichier à téléverser'
 					},
+					'hi': {
+						'file_upload_text': 'ड्रैग और ड्रॉप करें या',
+						'browse': 'ब्राउज़ करें',
+						'browse_files': 'फ़ाइलें ब्राउज़ करें',
+						'choose_one_file_to_upload': 'कोई फ़ाइल अपलोड करने के लिए चुनें'
+					},
 					'ja': {
 						'file_upload_text': 'ドラッグ＆ドロップまたは',
 						'browse': '参照',


### PR DESCRIPTION
Backports the Hindi translations into the older 2.x version.