### PR TITLE
Use dynamic lang import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,8 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Install dependencies
-        run: |
-          npm install
-          npm install @web/test-runner-playwright --no-save
-          npx playwright install-deps
+        run: npm install
       - name: Lint (JavaScript)
         run: npm run lint
       - name: Unit Tests (cross-browser)
-        run: npx web-test-runner --files ./test/*.test.js --node-resolve --playwright --browsers chromium firefox webkit
+        run: npm run test:headless

--- a/localize-behavior.js
+++ b/localize-behavior.js
@@ -1,21 +1,3 @@
-import ar from './lang/ar.js';
-import cy from './lang/cy.js';
-import da from './lang/da.js';
-import de from './lang/de.js';
-import en from './lang/en.js';
-import eses from './lang/es-es.js';
-import es from './lang/es.js';
-import frfr from './lang/fr-fr.js';
-import fr from './lang/fr.js';
-import hi from './lang/hi.js';
-import ja from './lang/ja.js';
-import ko from './lang/ko.js';
-import nl from './lang/nl.js';
-import pt from './lang/pt.js';
-import sv from './lang/sv.js';
-import tr from './lang/tr.js';
-import zhcn from './lang/zh-cn.js';
-import zhtw from './lang/zh-tw.js';
 import '@brightspace-ui/localize-behavior/d2l-localize-behavior.js';
 window.D2L = window.D2L || {};
 window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
@@ -23,31 +5,8 @@ window.D2L.PolymerBehaviors.FileUploader = window.D2L.PolymerBehaviors.FileUploa
 
 /** @polymerBehavior D2L.PolymerBehaviors.FileUploader.LocalizeBehavior */
 D2L.PolymerBehaviors.FileUploader.LocalizeBehaviorImpl = {
-	properties: {
-		resources: {
-			value: function() {
-				return {
-					'ar': ar,
-					'cy': cy,
-					'da': da,
-					'de': de,
-					'en': en,
-					'es': es,
-					'es-es': eses,
-					'fr': fr,
-					'fr-fr': frfr,
-					'hi': hi,
-					'ja': ja,
-					'ko': ko,
-					'nl': nl,
-					'pt': pt,
-					'sv': sv,
-					'tr': tr,
-					'zh-cn': zhcn,
-					'zh-tw': zhtw
-				};
-			}
-		}
+	localizeConfig: {
+		importFunc: async lang => (await import(`./lang/${lang}.js`)).default
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -10,16 +10,15 @@
     "lint": "eslint . --ext .js,.html",
     "start": "web-dev-server --app-index demo/index.html --node-resolve --open --watch",
     "test": "npm run lint && npm run test:headless",
-    "test:headless": "web-test-runner --files ./test/*.test.js --node-resolve"
+    "test:headless": "d2l-test-runner"
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
     "@babel/core": "^7",
     "@babel/eslint-parser": "^7",
-    "@open-wc/testing": "^3",
+    "@brightspace-ui/testing": "^0.34",
     "@web/dev-server": "^0.2",
-    "@web/test-runner": "^0.13",
     "eslint": "^8",
     "eslint-config-brightspace": "^0.17",
     "eslint-plugin-html": "^6",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/core": "^7",
     "@babel/eslint-parser": "^7",
-    "@brightspace-ui/testing": "^0.34",
+    "@brightspace-ui/testing": "^1",
     "@web/dev-server": "^0.2",
     "eslint": "^8",
     "eslint-config-brightspace": "^0.17",

--- a/test/d2l-file-uploader.test.js
+++ b/test/d2l-file-uploader.test.js
@@ -1,15 +1,10 @@
 import '../d2l-file-uploader.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import sinon from 'sinon';
 
 describe('d2l-file-uploader', () => {
 
-	let elem, htmlElem;
-
-	beforeEach(() => {
-		htmlElem = window.document.getElementsByTagName('html')[0];
-		htmlElem.removeAttribute('lang');
-	});
+	let elem;
 
 	describe('basic', () => {
 
@@ -115,8 +110,7 @@ describe('d2l-file-uploader', () => {
 	describe('language', () => {
 
 		beforeEach(async() => {
-			htmlElem.setAttribute('lang', 'fr');
-			elem = await fixture(html`<d2l-labs-file-uploader></d2l-labs-file-uploader>`);
+			elem = await fixture(html`<d2l-labs-file-uploader></d2l-labs-file-uploader>`, { lang: 'fr' });
 			await new Promise(resolve => { requestAnimationFrame(resolve); });
 		});
 


### PR DESCRIPTION
Polymer components can now use dynamic imports for language files. I also switched to the new `@brightspace-ui/testing` library to help test the changes more easily.